### PR TITLE
Allow access to XDG_DATA_HOME SlimeVR socket path

### DIFF
--- a/io.github.wivrn.wivrn.yml
+++ b/io.github.wivrn.wivrn.yml
@@ -35,10 +35,11 @@ finish-args:
   # Set the active OpenXR / OpenVR runtime
   - --filesystem=xdg-config/openxr:create
   - --filesystem=xdg-config/openvr:create
-  # SlimeVR
+  # Access to SlimeVR IPC sockets
   - --filesystem=xdg-run/SlimeVRInput
   - --filesystem=xdg-run/SlimeVRRpc
   - --filesystem=xdg-run/.flatpak/dev.slimevr.SlimeVR
+  - --filesystem=xdg-data/dev.slimevr.SlimeVR
   # Let outside application access the WiVRn socket
   - --filesystem=xdg-run/wivrn:create
   - --own-name=io.github.wivrn.Server


### PR DESCRIPTION
Used when running SlimeVR in Steam: https://github.com/SlimeVR/SlimeVR-Server/blob/61687a27ca1d5ee4eee98dc4b244b0687536d58e/server/core/src/main/java/io/eiren/util/OperatingSystem.kt#L42